### PR TITLE
Add getenv_strict variant

### DIFF
--- a/src/ppx_getenv.ml
+++ b/src/ppx_getenv.ml
@@ -2,18 +2,27 @@ open Ppxlib
 
 let getenv s = try Sys.getenv s with Not_found -> ""
 
-let expander ~loc ~path:_ = function
+let getenv_strict ~loc s =
+  try Sys.getenv s
+  with Not_found -> Location.raise_errorf ~loc "[%%getenv_strict] not set: %s" s
+
+let expander ~strict ~loc ~path:_ = function
   | (* Should have a single structure item, which is evaluation of a constant string. *)
     PStr [{ pstr_desc =
             Pstr_eval ({ pexp_loc  = loc;
                          pexp_desc = Pexp_constant (Pconst_string (sym, _, None)); _ }, _); _ }] ->
       (* Replace with a constant string with the value from the environment. *)
-      Ast_builder.Default.estring ~loc (getenv sym)
+      Ast_builder.Default.estring ~loc (if strict then getenv_strict ~loc sym else getenv sym)
   | _ ->
       Location.raise_errorf ~loc "[%%getenv] accepts a string, e.g. [%%getenv \"USER\"]"
 
 let extension =
   Context_free.Rule.extension
-    (Extension.declare "getenv" Expression Ast_pattern.(__) expander)
+    (Extension.declare "getenv" Expression Ast_pattern.(__) (expander ~strict:false))
+
+let extension_strict =
+  Context_free.Rule.extension
+    (Extension.declare "getenv_strict" Expression Ast_pattern.(__) (expander ~strict:true))
 
 let () = Ppxlib.Driver.register_transformation ~rules:[extension] "ppx_getenv"
+let () = Ppxlib.Driver.register_transformation ~rules:[extension_strict] "ppx_getenv_strict"


### PR DESCRIPTION
Hi! I often find the `getenv` ppx very useful, but one thing that is missing from it is the ability to statically fail when the environment variable is not set.

This implements a new extension `getenv_strict` that encountering a missing environment variable will fail with:

```
File "src_test/test_ppx_getenv.ml", line 5, characters 36-55:
5 |   assert_equal "42" [%getenv_strict "PPX_GETENV_CHECK_MISSING"]
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^
Error: [%getenv_strict] not set: PPX_GETENV_CHECK_MISSING
```

If you think this is a good addition, I'm happy to document this in the README and add a test case.